### PR TITLE
remove Creative Black Country from website

### DIFF
--- a/django/general/templates/general/about.html
+++ b/django/general/templates/general/about.html
@@ -34,7 +34,7 @@
             <strong>Media</strong> explores the extent and type of representation of Germany and Poland (especially German and Polish history) as well as of German and Polish immigrants in the UK press and social media. Exploring how the UK press reports on these topics allows us to understand the discursive space in which and against which Germans and Poles in the UK define and develop their political identities and how this might interact with memories of the country of origin.
         </li>
         <li>
-            <strong>Communities</strong> explores the ways in which individuals give voice to their memories in dialogue others. Research in this strand centres on series of photography workshops in two urban areas: West Bromwich and Hyson Green. The idea is to foster inter-community dialogue around memories of the past and their connection to the present political moment. The photographs, narratives and recordings of the story exchanges produced in the workshops will form the subject of an exhibition developed by the community in co-operation with Centrala and an Artist in Residence (AiR). Community engagement with the outputs of this strand will be further enhanced by the hosting of the exhibition in Sandwell in July 2023 and the commissioning by project partners Creative Black Country (CBC) of a series of artistic performances (e.g., spoken word, theatre, comedy) around the work.
+            <strong>Communities</strong> explores the ways in which individuals give voice to their memories in dialogue others. Research in this strand centres on series of photography workshops in two urban areas: West Bromwich and Hyson Green. The idea is to foster inter-community dialogue around memories of the past and their connection to the present political moment. The photographs, narratives and recordings of the story exchanges produced in the workshops will form the subject of an exhibition developed by the community in co-operation with Centrala and an Artist in Residence (AiR).
         </li>
     </ul>
 </section>
@@ -97,13 +97,6 @@
     </div>
 
     <div class="about-partners-partner">
-        <img src="{% static 'images/partners/cbc.jpg' %}" alt="CBC">
-        <p>
-            Creative Black Country (CBC) is a community interest organisation seeking to improve engagement with the arts in the region. CBC will showcase the exhibition in Sandwell in July 2023 and commission a series of artistic engagement events around it (spoken word, theatre, comedy).
-        </p>
-    </div>
-
-    <div class="about-partners-partner">
         <img src="{% static 'images/partners/polish-professionals-london.png' %}" alt="Polish Professionals London">
         <p>
             Polish Professionals in London is a non-profit organisation that brings together professionals from a wide range of disciplines. Polish Professionals support with the delivery of the stakeholder workshops and engagement with relevant communities.
@@ -131,7 +124,6 @@
     <ul>
         <li>Dr Laura Alvarez (Senior Urban Planner, Nottingham City Council)</li>
         <li>Dr Kathy Burrell (University of Liverpool)</li>
-        <li>Sajida Carr (Director of Development and Operations, Creative Black Country)</li>
         <li>Cllr John Cotton (Glebe Farm and Tile Cross)</li>
         <li>Prof. Astrid Erll (Goethe University, Frankfurt)</li>
         <li>Prof. Jennifer Evans (Carleton University)</li>


### PR DESCRIPTION
Request from Sara:

```
Hi Mike,
So sorry to make this request so soon after the website is finished; however, I’ve just learned that Creative Black Country are no longer able to take part in the project. Could you therefore delete the following from the ‘About’ page:
 
Last sentence of ‘Communities’ strand: “Community engagement with the outputs of this strand will be further enhanced by the hosting of the exhibition in Sandwell in July 2023 and the commissioning by project partners Creative Black Country (CBC) of a series of artistic performances (e.g., spoken word, theatre, comedy) around the work.”
 
Whole of the Creative Black Country entry on the list of team members.
 
Sajida Carr from list of Advisory Board members.
 
Many thanks!
Sara
```