### PR TITLE
fixed community list preview text

### DIFF
--- a/django/communities/templates/communities/story-list.html
+++ b/django/communities/templates/communities/story-list.html
@@ -22,7 +22,7 @@
             {% for object in object_list %}
                 <a href="{% url 'communities:story-detail' object.id %}" class="stories-list-item">
                     <div class="stories-list-item-name"> {{ object.story_name }}</div>
-                    <div class="stories-list-item-text"> {{ object.story_text | striptags | truncatechars:50 }}</div>
+                    <div class="stories-list-item-text"> {{ object.story_text | striptags | safe }}</div>
                     <div class="stories-list-item-details">
                         {% if object.story_theme %}
                             <span>Theme: {{ object.story_theme }}</span>


### PR DESCRIPTION
Text isn't displaying correctly on the list page for 'community' section: <https://postsocialistbritain.bham.ac.uk/communities/> which this PR fixes